### PR TITLE
chore(secp256k1): Encoders and decoders

### DIFF
--- a/src/ecdsa/secp256k1.tests/public_key.test.ts
+++ b/src/ecdsa/secp256k1.tests/public_key.test.ts
@@ -76,6 +76,27 @@ describe('ChainCode', () => {
 				)
 		).toThrow();
 	});
+	it('should hex decode and encode', () => {
+		const chain_code = '000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f';
+		const chain_code_from_hex = ChainCode.fromHex(chain_code);
+		expect(chain_code_from_hex.toHex()).toBe(chain_code);
+	});
+	it('should blob decode and encode', () => {
+		const chain_code =
+			'\\00\\01\\02\\03\\04\\05\\06\\07\\08\\09\\0a\\0b\\0c\\0d\\0e\\0f\\10\\11\\12\\13\\14\\15\\16\\17\\18\\19\\1a\\1b\\1c\\1d\\1e\\1f';
+		const chain_code_from_blob = ChainCode.fromBlob(chain_code);
+		const chain_code_from_blob_encoded = chain_code_from_blob.toBlob();
+		expect(chain_code_from_blob_encoded).toBe(chain_code);
+	});
+	it('should parse both hex and blob chain codes', () => {
+		const hex_chain_code = '000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f';
+		const blob_chain_code =
+			'\\00\\01\\02\\03\\04\\05\\06\\07\\08\\09\\0a\\0b\\0c\\0d\\0e\\0f\\10\\11\\12\\13\\14\\15\\16\\17\\18\\19\\1a\\1b\\1c\\1d\\1e\\1f';
+		const blob2hex = ChainCode.fromString(blob_chain_code).toHex();
+		const hex2blob = ChainCode.fromString(hex_chain_code).toBlob();
+		expect(blob2hex).toBe(hex_chain_code);
+		expect(hex2blob).toBe(blob_chain_code);
+	});
 });
 
 describe('PublicKeyWithChainCode', () => {
@@ -85,5 +106,38 @@ describe('PublicKeyWithChainCode', () => {
 		const public_key_with_chain_code = PublicKeyWithChainCode.fromHex({ public_key, chain_code });
 		const public_key_with_chain_code_hex = public_key_with_chain_code.toHex();
 		expect(public_key_with_chain_code_hex).toStrictEqual({ public_key, chain_code });
+	});
+	it('should blob decode and encode', () => {
+		const public_key =
+			'\\00\\01\\02\\03\\04\\05\\06\\07\\08\\09\\0a\\0b\\0c\\0d\\0e\\0f\\10\\11\\12\\13\\14\\15\\16\\17\\18\\19\\1a\\1b\\1c\\1d\\1e\\1f\\20';
+		const chain_code =
+			'\\00\\01\\02\\03\\04\\05\\06\\07\\08\\09\\0a\\0b\\0c\\0d\\0e\\0f\\10\\11\\12\\13\\14\\15\\16\\17\\18\\19\\1a\\1b\\1c\\1d\\1e\\1f';
+		const public_key_with_chain_code = PublicKeyWithChainCode.fromBlob({ public_key, chain_code });
+	});
+	it('should parse both hex and blob public keys and chain codes', () => {
+		const hex_public_key = '000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f20';
+		const blob_public_key =
+			'\\00\\01\\02\\03\\04\\05\\06\\07\\08\\09\\0a\\0b\\0c\\0d\\0e\\0f\\10\\11\\12\\13\\14\\15\\16\\17\\18\\19\\1a\\1b\\1c\\1d\\1e\\1f\\20';
+		const hex_chain_code = '000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f';
+		const blob_chain_code =
+			'\\00\\01\\02\\03\\04\\05\\06\\07\\08\\09\\0a\\0b\\0c\\0d\\0e\\0f\\10\\11\\12\\13\\14\\15\\16\\17\\18\\19\\1a\\1b\\1c\\1d\\1e\\1f';
+		for (const public_key of [hex_public_key, blob_public_key]) {
+			for (const chain_code of [hex_chain_code, blob_chain_code]) {
+				let public_key_with_chain_code = PublicKeyWithChainCode.fromString({
+					public_key,
+					chain_code
+				});
+				let public_key_with_chain_code_hex = public_key_with_chain_code.toHex();
+				let public_key_with_chain_code_blob = public_key_with_chain_code.toBlob();
+				expect(public_key_with_chain_code_hex).toStrictEqual({
+					public_key: hex_public_key,
+					chain_code: hex_chain_code
+				});
+				expect(public_key_with_chain_code_blob).toStrictEqual({
+					public_key: blob_public_key,
+					chain_code: blob_chain_code
+				});
+			}
+		}
 	});
 });

--- a/src/ecdsa/secp256k1.ts
+++ b/src/ecdsa/secp256k1.ts
@@ -47,6 +47,32 @@ export class PublicKeyWithChainCode {
 	}
 
 	/**
+	 * @returns The public key and chain code as Candid blobs.
+	 */
+	toBlob(): { public_key: string; chain_code: string } {
+		return { public_key: this.public_key.toBlob(), chain_code: this.chain_code.toBlob() };
+	}
+
+	/**
+	 * Creates a new PublicKeyWithChainCode from two Candid blobs.
+	 * @param public_key The public key as a Candid blob.
+	 * @param chain_code The chain code as a Candid blob.
+	 * @returns A new PublicKeyWithChainCode.
+	 */
+	static fromBlob({
+		public_key,
+		chain_code
+	}: {
+		public_key: string;
+		chain_code: string;
+	}): PublicKeyWithChainCode {
+		return new PublicKeyWithChainCode(
+			Sec1EncodedPublicKey.fromBlob(public_key),
+			ChainCode.fromBlob(chain_code)
+		);
+	}
+
+	/**
 	 * Creates a new PublicKeyWithChainCode from two strings.
 	 * @param public_key The public key in any supported format.
 	 * @param chain_code The chain code in any supported format.
@@ -122,6 +148,11 @@ export class Sec1EncodedPublicKey {
 	 * @returns A new Sec1EncodedPublicKey.
 	 */
 	static fromHex(hex: string): Sec1EncodedPublicKey {
+		if (hex.length !== Sec1EncodedPublicKey.LENGTH * 2) {
+			throw new Error(
+				`Invalid PublicKey length: expected ${Sec1EncodedPublicKey.LENGTH * 2} characters, got ${hex.length}`
+			);
+		}
 		const bytes = Buffer.from(hex, 'hex');
 		return new Sec1EncodedPublicKey(new Uint8Array(bytes));
 	}
@@ -178,11 +209,16 @@ export class ChainCode {
 
 	/**
 	 * Creates a new ChainCode from a 64 character hex string.
-	 * @param hex The 64 character hex string.
+	 * @param hex_str The 64 character hex string.
 	 * @returns A new ChainCode.
 	 */
-	static fromHex(hex: string): ChainCode {
-		const bytes = Buffer.from(hex, 'hex');
+	static fromHex(hex_str: string): ChainCode {
+		if (hex_str.length !== ChainCode.LENGTH * 2) {
+			throw new Error(
+				`Invalid ChainCode length: expected ${ChainCode.LENGTH * 2} characters, got ${hex_str.length}`
+			);
+		}
+		const bytes = Buffer.from(hex_str, 'hex');
 		return new ChainCode(new Uint8Array(bytes));
 	}
 


### PR DESCRIPTION
# Motivation
To be useful, the library needs to be able to consume common formats.

# Changes
- Add hex and blob encoding and decoding methods.

# Tests
- Unit tests are included