### PR TITLE
feat(schnorr/bip340secp256k1): Non-curve specific part of derivation paths

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,6 @@
 // Elliptic curves:
 export * as ecdsa from './ecdsa/index';
-// TODO: export * as schnorr from './schnorr/index';
+export * as schnorr from './schnorr/index';
 
 // Utilities for working with the Chain Fusion Signer:
 // Equivalent to the `npx signer` commands:

--- a/src/schnorr/bip340secp256k1.tests/derivation_path.test.ts
+++ b/src/schnorr/bip340secp256k1.tests/derivation_path.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, it } from 'vitest';
+import { DerivationPath } from '../bip340secp256k1';
+
+interface BlobEncodingTestVector {
+	name: string;
+	blob: string | null;
+	path: DerivationPath;
+}
+
+const blobEncodingTestVectors: BlobEncodingTestVector[] = [
+	{
+		name: 'empty path',
+		blob: null,
+		path: new DerivationPath([])
+	},
+	{
+		name: 'simple path',
+		blob: 'hello',
+		path: new DerivationPath([Buffer.from('68656c6c6f', 'hex')])
+	},
+	{
+		name: 'multi part path',
+		blob: 'multi/part/path',
+		path: new DerivationPath([
+			Buffer.from('6d756c7469', 'hex'),
+			Buffer.from('70617274', 'hex'),
+			Buffer.from('70617468', 'hex')
+		])
+	},
+	{
+		name: 'path with empty elements',
+		blob: '//aloha/',
+		path: new DerivationPath([
+			Buffer.alloc(0),
+			Buffer.alloc(0),
+			Buffer.from('616c6f6861', 'hex'),
+			Buffer.alloc(0)
+		])
+	}
+];
+
+describe('DerivationPath', () => {
+	describe('toBlob', () => {
+		for (const testVector of blobEncodingTestVectors) {
+			it(testVector.name, () => {
+				const encoded = testVector.path.toBlob();
+				expect(encoded).toBe(testVector.blob);
+			});
+		}
+	});
+});

--- a/src/schnorr/bip340secp256k1.tests/derivation_path.test.ts
+++ b/src/schnorr/bip340secp256k1.tests/derivation_path.test.ts
@@ -48,4 +48,13 @@ describe('DerivationPath', () => {
 			});
 		}
 	});
+	describe('fromBlob', () => {
+		for (const testVector of blobEncodingTestVectors) {
+			it(testVector.name, () => {
+				const decoded = DerivationPath.fromBlob(testVector.blob);
+				const encoded = decoded.toBlob(); // TODO: Implement equality on derivation paths.
+				expect(encoded).toBe(testVector.blob);
+			});
+		}
+	});
 });

--- a/src/schnorr/bip340secp256k1.ts
+++ b/src/schnorr/bip340secp256k1.ts
@@ -30,22 +30,5 @@ export class DerivationPath {
 		return this.path.map((p) => blobEncode(p)).join('/');
 	}
 
-	/**
-	 * Compares this DerivationPath with another to check for equality.
-	 * @param other The DerivationPath to compare with.
-	 * @returns True if both paths are equal, false otherwise.
-	 */
-	equals(other: DerivationPath): boolean {
-		if (!(other instanceof DerivationPath)) {
-			return false;
-		}
-		if (this.path.length !== other.path.length) {
-			return false;
-		}
-		return this.path.every((component, index) =>
-			component.length === other.path[index].length &&
-			component.every((byte, byteIndex) => byte === other.path[index][byteIndex])
-		);
-	}
 	// TODO: Curve-specific methods.
 }

--- a/src/schnorr/bip340secp256k1.ts
+++ b/src/schnorr/bip340secp256k1.ts
@@ -30,5 +30,22 @@ export class DerivationPath {
 		return this.path.map((p) => blobEncode(p)).join('/');
 	}
 
+	/**
+	 * Compares this DerivationPath with another to check for equality.
+	 * @param other The DerivationPath to compare with.
+	 * @returns True if both paths are equal, false otherwise.
+	 */
+	equals(other: DerivationPath): boolean {
+		if (!(other instanceof DerivationPath)) {
+			return false;
+		}
+		if (this.path.length !== other.path.length) {
+			return false;
+		}
+		return this.path.every((component, index) =>
+			component.length === other.path[index].length &&
+			component.every((byte, byteIndex) => byte === other.path[index][byteIndex])
+		);
+	}
 	// TODO: Curve-specific methods.
 }

--- a/src/schnorr/bip340secp256k1.ts
+++ b/src/schnorr/bip340secp256k1.ts
@@ -1,0 +1,34 @@
+import { blobDecode, blobEncode } from '../encoding.js';
+
+/**
+ * One part of a derivation path.
+ */
+export type PathComponent = Uint8Array;
+
+export class DerivationPath {
+	constructor(public readonly path: PathComponent[]) {}
+
+	/**
+	 * Creates a new DerivationPath from / separated candid blobs.
+	 * @param blob The / separated blobs to create the derivation path from.
+	 * @returns A new DerivationPath.
+	 */
+	static fromBlob(blob: string | undefined | null): DerivationPath {
+		if (blob === undefined || blob === null) {
+			return new DerivationPath([]);
+		}
+		return new DerivationPath(blob.split('/').map((p) => blobDecode(p)));
+	}
+
+	/**
+	 * @returns A string representation of the derivation path: Candid blob encoded with a '/' between each path component.
+	 */
+	toBlob(): string | null {
+		if (this.path.length === 0) {
+			return null;
+		}
+		return this.path.map((p) => blobEncode(p)).join('/');
+	}
+
+	// TODO: Curve-specific methods.
+}

--- a/src/schnorr/index.ts
+++ b/src/schnorr/index.ts
@@ -1,2 +1,1 @@
-
 export * as bip340secp256k1 from './bip340secp256k1.js';

--- a/src/schnorr/index.ts
+++ b/src/schnorr/index.ts
@@ -1,3 +1,2 @@
-#!/usr/bin/env node
 
 export * as bip340secp256k1 from './bip340secp256k1.js';

--- a/src/schnorr/index.ts
+++ b/src/schnorr/index.ts
@@ -1,0 +1,3 @@
+#!/usr/bin/env node
+
+export * as bip340secp256k1 from './bip340secp256k1.js';


### PR DESCRIPTION
# Motivation
Mirroring the Rust installation, each curve has its own derivation class type.

# Changes
- Add a constructor and serialization/deserialization methods for schnorr/bip340secp256k1 derivation paths.

Note: This is largely the same as for ecdsa/secp256k1.  It may be possible to factor out the common parts in a future PR.  In the interest of development speed we will make duplicates first and optimize later.

# Tests
Unit tests are included.