### PR TITLE
chore(eslint): Ignore html

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -9,6 +9,7 @@ export default [
 			'node_modules/',
 			'dist/',
 			'target/',
+			'html/',
 			'*.min.js',
 			'*.bundle.js',
 			'coverage/',


### PR DESCRIPTION
# Motivation
The html/ directory contains an auto-generated report.  The code in that report causes a lot of eslint warnings.

# Changes
- Ignore `html/` in eslint.

# Tests
