### PR TITLE
refactor: Make zschnorrEd25519Derivez service return the response

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -92,18 +92,18 @@ FmK8wmdFM72z4vKzzyYWYi7W5sReALBS72BHn6mDDJPh
 	)
 	.addOption(new Option('-d, --derivationpath <string>', 'The derivation path'))
 	.action(({ pubkey, chaincode, derivationpath }) => {
-		const pubkey_or_default: string = isNullish(pubkey)
+		const pubkeyOrDefault: string = isNullish(pubkey)
 			? 'da38b16641af7626e372070ff9f844b7c89d1012850d2198393849d79d3d2d5d'
 			: String(pubkey);
-		const chaincode_or_default: string = isNullish(chaincode)
+		const chaincodeOrDefault: string = isNullish(chaincode)
 			? '985be5283a68fc22540930ca02680f86c771419ece571eb838b33eb5604cfbc0'
 			: String(chaincode);
-		const derivationpath_or_null: string | null = isNullish(derivationpath)
+		const derivationPathOrNull: string | null = isNullish(derivationpath)
 			? null
 			: String(derivationpath);
-		console.log(
-			schnorrEd25519Derive(pubkey_or_default, chaincode_or_default, derivationpath_or_null)
-		);
+
+		const ans = schnorrEd25519Derive(pubkeyOrDefault, chaincodeOrDefault, derivationPathOrNull);
+		console.log(JSON.stringify(ans, null, 2));
 	});
 
 const signer = program.command('signer').description('Get chain fusion signer token address');

--- a/src/schnorr/ed25519.ts
+++ b/src/schnorr/ed25519.ts
@@ -3,6 +3,7 @@ import { hkdf as nobleHkdf } from '@noble/hashes/hkdf.js';
 import { sha512 } from '@noble/hashes/sha2';
 import { ChainCode } from '../chain_code.js';
 import { bigintFromBigEndianBytes, blobDecode, blobEncode } from '../encoding.js';
+
 export { ChainCode };
 
 /**
@@ -206,23 +207,29 @@ export function offsetFromOkm(okm: Uint8Array): bigint {
  *
  * @param pubkey A hexadecimal string representing the public key. It must be 64 characters long.
  * @param chaincode A hexadecimal string representing the chain code. It must be 64 characters long.
- * @param derivationpath A string representing the derivation path in a serialized format, or `null` if no derivation path is provided.
- * @returns A JSON string containing the derived public key, chain code, and the derivation path used.
+ * @param derivationPath A string representing the derivation path in a serialized format, or `null` if no derivation path is provided.
+ * @returns A structured object containing the request and response for the derivation operation.
  */
 export function schnorrEd25519Derive(
 	pubkey: string,
 	chaincode: string,
-	derivationpath: string | null
-): string {
-	const pubkey_with_chain_code = PublicKeyWithChainCode.fromString(pubkey, chaincode);
-	const parsed_derivationpath = DerivationPath.fromBlob(derivationpath);
-	const derived_pubkey = pubkey_with_chain_code.deriveSubkeyWithChainCode(parsed_derivationpath);
-	const ans = {
-		request: {
-			key: pubkey_with_chain_code,
-			derivation_path: parsed_derivationpath
-		},
-		response: derived_pubkey
+	derivationPath: string | null
+): {
+	request: {
+		key: PublicKeyWithChainCode;
+		derivation_path: DerivationPath;
 	};
-	return JSON.stringify(ans, null, 2);
+	response: PublicKeyWithChainCode;
+} {
+	const publicKeyWithChainCode = PublicKeyWithChainCode.fromString(pubkey, chaincode);
+	const parsedDerivationPath = DerivationPath.fromBlob(derivationPath);
+	const derivedPubkey = publicKeyWithChainCode.deriveSubkeyWithChainCode(parsedDerivationPath);
+
+	return {
+		request: {
+			key: publicKeyWithChainCode,
+			derivation_path: parsedDerivationPath
+		},
+		response: derivedPubkey
+	};
 }


### PR DESCRIPTION
# Motivation

Since service `schnorrEd25519Derive` is going to be re-used by any number of consumer, it would be preferably that it returns an object with the response, instead of printing to console.

# Changes

- Change the return type of `schnorrEd25519Derive` to be a structure with request and response (similar to other services in the library).
- Adapt the CLI methods to print to console as before.
- Change all variable related to `schnorrEd25519Derive` to use camelCase.

# Tests

Current tests should work as expected. Nothing changed.
