### PR TITLE
feat(crypto): CRP-2811 Add mainnet production keys and BIP340 derivation

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,10 +2,19 @@
 
 TypeScript library for working with ICP public keys.
 
-This library contains TypeScript translations of the following functions:
+The Internet Computer protcol supports several threshold signature schemes
+including ECDSA, Ed25519, and BIP340 Schnorr. In these schemes, the various user
+public keys are derived from a master key which is split among the nodes in a
+subnet. This derivation can be done online, using the `ecdsa_public_key` and
+`schnorr_public_key` management canister calls, but since no secret is involved
+in the derivation process it can also be performed offline.
 
-- [`ic_secp256k1::PublicKey::derive_subkey_with_chain_code()`](https://docs.rs/ic-secp256k1/0.1.0/ic_secp256k1/struct.PublicKey.html#method.derive_subkey_with_chain_code)
-- COMING: [`ic_ed25519::PublicKey::derive_subkey_with_chain_code()`](https://docs.rs/ic-ed25519/0.2.0/ic_ed25519/struct.PublicKey.html#method.derive_subkey_with_chain_code)
+This library contains TypeScript implementations of this derivation, allowing
+keys to be derived by frontend applications without a call to the IC.
+
+You can find Rust implementations of this same functionality in the
+[`ic_secp256k1`](https://docs.rs/ic-secp256k1/) and [`ic_ed25519`](https://docs.rs/ic-ed25519/)
+crates.
 
 # Usage
 

--- a/src/ecdsa/secp256k1.tests/mainnet_derivation.test.ts
+++ b/src/ecdsa/secp256k1.tests/mainnet_derivation.test.ts
@@ -1,0 +1,40 @@
+import { Principal } from '@dfinity/principal';
+import { describe, expect, it } from 'vitest';
+import { DerivationPath, PublicKeyWithChainCode } from '../secp256k1';
+
+describe('Mainnet Derivation', () => {
+	it('should match mainnet test_key_1 derivation', () => {
+		const mk = PublicKeyWithChainCode.forMainnetKey('test_key_1');
+		const canisterId = Principal.fromText('h5jwf-5iaaa-aaaan-qmvoa-cai');
+		const path = DerivationPath.withCanisterPrefix(canisterId, [
+			Buffer.from('48656C6C6F', 'hex'),
+			Buffer.from('5468726573686F6C64', 'hex'),
+			Buffer.from('5369676E617475726573', 'hex')
+		]);
+
+		// Derive the new key
+		const derivedKey = mk.deriveSubkeyWithChainCode(path);
+
+		// Check the results
+		expect(derivedKey.public_key.toHex()).toEqual(
+			'0315ae8bb8c6e9f78eec2167f5ac773067f37a39da1a1efbc585f9e90658d1c620'
+		);
+	});
+
+	it('should match mainnet key_1 derivation', () => {
+		const mk = PublicKeyWithChainCode.forMainnetKey('key_1');
+		const canisterId = Principal.fromText('h5jwf-5iaaa-aaaan-qmvoa-cai');
+		const path = DerivationPath.withCanisterPrefix(canisterId, [
+			Buffer.from('ABCDEF', 'hex'),
+			Buffer.from('012345', 'hex')
+		]);
+
+		// Derive the new key
+		const derivedKey = mk.deriveSubkeyWithChainCode(path);
+
+		// Check the results
+		expect(derivedKey.public_key.toHex()).toEqual(
+			'02735ca28b5c3e380016d7f28bf4703b540a8bbe8e24beffdc021455ca2ab93fe3'
+		);
+	});
+});

--- a/src/ecdsa/secp256k1.ts
+++ b/src/ecdsa/secp256k1.ts
@@ -1,3 +1,4 @@
+import { Principal } from '@dfinity/principal';
 import { hmac } from '@noble/hashes/hmac';
 import { sha512 } from '@noble/hashes/sha2';
 import { bytesToHex } from '@noble/hashes/utils';
@@ -23,6 +24,29 @@ export class PublicKeyWithChainCode {
 		public readonly public_key: Sec1EncodedPublicKey,
 		public readonly chain_code: ChainCode
 	) {}
+
+	/**
+	 * Return the master public key used in the production mainnet
+	 */
+	static forMainnetKey(key_id: string): PublicKeyWithChainCode {
+		const chain_key = ChainCode.fromHex(
+			'0000000000000000000000000000000000000000000000000000000000000000'
+		);
+
+		if (key_id == 'key_1') {
+			const public_key = Sec1EncodedPublicKey.fromHex(
+				'02121bc3a5c38f38ca76487c72007ebbfd34bc6c4cb80a671655aa94585bbd0a02'
+			);
+			return new PublicKeyWithChainCode(public_key, chain_key);
+		} else if (key_id == 'test_key_1') {
+			const public_key = Sec1EncodedPublicKey.fromHex(
+				'02f9ac345f6be6db51e1c5612cddb59e72c3d0d493c994d12035cf13257e3b1fa7'
+			);
+			return new PublicKeyWithChainCode(public_key, chain_key);
+		} else {
+			throw new Error('Unknown master public key id');
+		}
+	}
 
 	/**
 	 * Creates a new PublicKeyWithChainCode from two hex strings.
@@ -216,6 +240,17 @@ export class DerivationPath {
 	static readonly ORDER = 0xfffffffffffffffffffffffffffffffebaaedce6af48a03bbfd25e8cd0364141n;
 
 	constructor(public readonly path: PathComponent[]) {}
+
+	/**
+	 * Creates a new DerivationPath from a canister identifier plus other path components
+	 * @param canisterId the id of the canister
+	 * @param path other path components
+	 */
+	static withCanisterPrefix(canisterId: Principal, path: PathComponent[]): DerivationPath {
+		const canisterIdBytes = canisterId.toUint8Array();
+		const newPath = [canisterIdBytes, ...path];
+		return new DerivationPath(newPath);
+	}
 
 	/**
 	 * Creates a new DerivationPath from / separated candid blobs.

--- a/src/schnorr/bip340secp256k1.tests/mainnet_derivation.test.ts
+++ b/src/schnorr/bip340secp256k1.tests/mainnet_derivation.test.ts
@@ -1,0 +1,40 @@
+import { Principal } from '@dfinity/principal';
+import { describe, expect, it } from 'vitest';
+import { DerivationPath, PublicKeyWithChainCode } from '../bip340secp256k1';
+
+describe('Mainnet Derivation', () => {
+	it('should match mainnet test_key_1 derivation', () => {
+		const mk = PublicKeyWithChainCode.forMainnetKey('test_key_1');
+		const canisterId = Principal.fromText('h5jwf-5iaaa-aaaan-qmvoa-cai');
+		const path = DerivationPath.withCanisterPrefix(canisterId, [
+			Buffer.from('48656C6C6F', 'hex'),
+			Buffer.from('5468726573686F6C64', 'hex'),
+			Buffer.from('5369676E617475726573', 'hex')
+		]);
+
+		// Derive the new key
+		const derivedKey = mk.deriveSubkeyWithChainCode(path);
+
+		// Check the results
+		expect(derivedKey.public_key.toHex()).toEqual(
+			'0237ca6a41c1db8ab40410445250a5d46fbec7f3e449c8f40f86d8622a4106cebd'
+		);
+	});
+
+	it('should match mainnet key_1 derivation', () => {
+		const mk = PublicKeyWithChainCode.forMainnetKey('key_1');
+		const canisterId = Principal.fromText('h5jwf-5iaaa-aaaan-qmvoa-cai');
+		const path = DerivationPath.withCanisterPrefix(canisterId, [
+			Buffer.from('ABCDEF', 'hex'),
+			Buffer.from('012345', 'hex')
+		]);
+
+		// Derive the new key
+		const derivedKey = mk.deriveSubkeyWithChainCode(path);
+
+		// Check the results
+		expect(derivedKey.public_key.toHex()).toEqual(
+			'03e5e92c2399985f82521b110ac3dbf697a6b9522002c0d31d0b7cd5352c343457'
+		);
+	});
+});

--- a/src/schnorr/bip340secp256k1.ts
+++ b/src/schnorr/bip340secp256k1.ts
@@ -1,34 +1,120 @@
-import { blobDecode, blobEncode } from '../encoding.js';
+import { ChainCode } from '../chain_code.js';
+
+import { DerivationPath, PathComponent, Sec1EncodedPublicKey } from '../ecdsa/secp256k1.js';
+
+export { ChainCode, DerivationPath, PathComponent, Sec1EncodedPublicKey };
 
 /**
- * One part of a derivation path.
+ * A public key with its chain code.
  */
-export type PathComponent = Uint8Array;
-
-export class DerivationPath {
-	constructor(public readonly path: PathComponent[]) {}
+export class PublicKeyWithChainCode {
+	/**
+	 * @param public_key The public key.
+	 * @param chain_code A hash of the derivation path.
+	 */
+	constructor(
+		public readonly public_key: Sec1EncodedPublicKey,
+		public readonly chain_code: ChainCode
+	) {}
 
 	/**
-	 * Creates a new DerivationPath from / separated candid blobs.
-	 * @param blob The / separated blobs to create the derivation path from.
-	 * @returns A new DerivationPath.
+	 * Return the master public key used in the production mainnet
 	 */
-	static fromBlob(blob: string | undefined | null): DerivationPath {
-		if (blob === undefined || blob === null) {
-			return new DerivationPath([]);
+	static forMainnetKey(key_id: string): PublicKeyWithChainCode {
+		const chain_key = ChainCode.fromHex(
+			'0000000000000000000000000000000000000000000000000000000000000000'
+		);
+
+		if (key_id == 'key_1') {
+			const public_key = Sec1EncodedPublicKey.fromHex(
+				'02246e29785f06d37a8a50c49f6152a34df74738f8c13a44f59fef4cbe90eb13ac'
+			);
+			return new PublicKeyWithChainCode(public_key, chain_key);
+		} else if (key_id == 'test_key_1') {
+			const public_key = Sec1EncodedPublicKey.fromHex(
+				'037a651a2e5ef3d1ef63e84c4c4caa029fa4a43a347a91e4d84a8e846853d51be1'
+			);
+			return new PublicKeyWithChainCode(public_key, chain_key);
+		} else {
+			throw new Error('Unknown master public key id');
 		}
-		return new DerivationPath(blob.split('/').map((p) => blobDecode(p)));
 	}
 
 	/**
-	 * @returns A string representation of the derivation path: Candid blob encoded with a '/' between each path component.
+	 * Creates a new PublicKeyWithChainCode from two hex strings.
+	 * @param public_key The public key as a 66 character hex string.
+	 * @param chain_code The chain code as a 64 character hex string.
+	 * @returns A new PublicKeyWithChainCode.
 	 */
-	toBlob(): string | null {
-		if (this.path.length === 0) {
-			return null;
-		}
-		return this.path.map((p) => blobEncode(p)).join('/');
+	static fromHex({
+		public_key,
+		chain_code
+	}: {
+		public_key: string;
+		chain_code: string;
+	}): PublicKeyWithChainCode {
+		return new PublicKeyWithChainCode(
+			Sec1EncodedPublicKey.fromHex(public_key),
+			ChainCode.fromHex(chain_code)
+		);
 	}
 
-	// TODO: Curve-specific methods.
+	/**
+	 * @returns The public key and chain code as hex strings.
+	 */
+	toHex(): { public_key: string; chain_code: string } {
+		return { public_key: this.public_key.toHex(), chain_code: this.chain_code.toHex() };
+	}
+
+	/**
+	 * @returns The public key and chain code as Candid blobs.
+	 */
+	toBlob(): { public_key: string; chain_code: string } {
+		return { public_key: this.public_key.toBlob(), chain_code: this.chain_code.toBlob() };
+	}
+
+	/**
+	 * Creates a new PublicKeyWithChainCode from two Candid blobs.
+	 * @param public_key The public key as a Candid blob.
+	 * @param chain_code The chain code as a Candid blob.
+	 * @returns A new PublicKeyWithChainCode.
+	 */
+	static fromBlob({
+		public_key,
+		chain_code
+	}: {
+		public_key: string;
+		chain_code: string;
+	}): PublicKeyWithChainCode {
+		return new PublicKeyWithChainCode(
+			Sec1EncodedPublicKey.fromBlob(public_key),
+			ChainCode.fromBlob(chain_code)
+		);
+	}
+
+	/**
+	 * Creates a new PublicKeyWithChainCode from two strings.
+	 * @param public_key The public key in any supported format.
+	 * @param chain_code The chain code in any supported format.
+	 * @returns A new PublicKeyWithChainCode.
+	 */
+	static fromString({
+		public_key,
+		chain_code
+	}: {
+		public_key: string;
+		chain_code: string;
+	}): PublicKeyWithChainCode {
+		return new PublicKeyWithChainCode(
+			Sec1EncodedPublicKey.fromString(public_key),
+			ChainCode.fromString(chain_code)
+		);
+	}
+
+	/**
+	 * Applies the given derivation path to obtain a new public key and chain code.
+	 */
+	deriveSubkeyWithChainCode(derivation_path: DerivationPath): PublicKeyWithChainCode {
+		return this.public_key.deriveSubkeyWithChainCode(derivation_path, this.chain_code);
+	}
 }

--- a/src/schnorr/ed25519.tests/mainnet_derivation.test.ts
+++ b/src/schnorr/ed25519.tests/mainnet_derivation.test.ts
@@ -1,0 +1,40 @@
+import { Principal } from '@dfinity/principal';
+import { describe, expect, it } from 'vitest';
+import { DerivationPath, PublicKeyWithChainCode } from '../ed25519';
+
+describe('Mainnet Derivation', () => {
+	it('should match mainnet test_key_1 derivation', () => {
+		const mk = PublicKeyWithChainCode.forMainnetKey('test_key_1');
+		const canisterId = Principal.fromText('h5jwf-5iaaa-aaaan-qmvoa-cai');
+		const path = DerivationPath.withCanisterPrefix(canisterId, [
+			Buffer.from('48656C6C6F', 'hex'),
+			Buffer.from('5468726573686F6C64', 'hex'),
+			Buffer.from('5369676E617475726573', 'hex')
+		]);
+
+		// Derive the new key
+		const derivedKey = mk.deriveSubkeyWithChainCode(path);
+
+		// Check the results
+		expect(derivedKey.public_key.toHex()).toEqual(
+			'd9a2ce6a3cd33fe16dce37e045609e51ff516e93bb51013823d6d7a915e3cfb9'
+		);
+	});
+
+	it('should match mainnet key_1 derivation', () => {
+		const mk = PublicKeyWithChainCode.forMainnetKey('key_1');
+		const canisterId = Principal.fromText('h5jwf-5iaaa-aaaan-qmvoa-cai');
+		const path = DerivationPath.withCanisterPrefix(canisterId, [
+			Buffer.from('ABCDEF', 'hex'),
+			Buffer.from('012345', 'hex')
+		]);
+
+		// Derive the new key
+		const derivedKey = mk.deriveSubkeyWithChainCode(path);
+
+		// Check the results
+		expect(derivedKey.public_key.toHex()).toEqual(
+			'43f0008b26564b6da51f585ad47669dfeb1db6d94d7dd216bd304fc1f5f5e997'
+		);
+	});
+});

--- a/src/schnorr/ed25519.ts
+++ b/src/schnorr/ed25519.ts
@@ -1,3 +1,4 @@
+import { Principal } from '@dfinity/principal';
 import { ExtendedPoint } from '@noble/ed25519';
 import { hkdf as nobleHkdf } from '@noble/hashes/hkdf.js';
 import { sha512 } from '@noble/hashes/sha2';
@@ -78,6 +79,29 @@ export class PublicKeyWithChainCode {
 	) {}
 
 	/**
+	 * Return the master public key used in the production mainnet
+	 */
+	static forMainnetKey(key_id: string): PublicKeyWithChainCode {
+		const chain_key = ChainCode.fromHex(
+			'0000000000000000000000000000000000000000000000000000000000000000'
+		);
+
+		if (key_id == 'key_1') {
+			const public_key = PublicKey.fromHex(
+				'476374d9df3a8af28d3164dc2422cff894482eadd1295290b6d9ad92b2eeaa5c'
+			);
+			return new PublicKeyWithChainCode(public_key, chain_key);
+		} else if (key_id == 'test_key_1') {
+			const public_key = PublicKey.fromHex(
+				'6c0824beb37621bcca6eecc237ed1bc4e64c9c59dcb85344aa7f9cc8278ee31f'
+			);
+			return new PublicKeyWithChainCode(public_key, chain_key);
+		} else {
+			throw new Error('Unknown master public key id');
+		}
+	}
+
+	/**
 	 * Creates a new PublicKeyWithChainCode from two hex strings.
 	 * @param public_key_hex The public key in hex format.
 	 * @param chain_code_hex The chain code in hex format.
@@ -114,6 +138,17 @@ export class PublicKeyWithChainCode {
 
 export class DerivationPath {
 	constructor(public readonly path: PathComponent[]) {}
+
+	/**
+	 * Creates a new DerivationPath from a canister identifier plus other path components
+	 * @param canisterId the id of the canister
+	 * @param path other path components
+	 */
+	static withCanisterPrefix(canisterId: Principal, path: PathComponent[]): DerivationPath {
+		const canisterIdBytes = canisterId.toUint8Array();
+		const newPath = [canisterIdBytes, ...path];
+		return new DerivationPath(newPath);
+	}
 
 	/**
 	 * Creates a new DerivationPath from / separated candid blobs.


### PR DESCRIPTION
Adding the master public keys used in the mainnet allows for fully offline key derivation for threshold ECDSA and threshold Schnorr.

This also adds derivation for BIP340 Schnorr, which is similar to ECDSA derivation, but using different master public keys.