### PR TITLE
chore: Add OISY team to CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -10,7 +10,7 @@
 #       If standard maintainers are not available, please contact GIX.
 * @bitdivine @randombit @AntonioVentilii
 
-# The codebase is owned by the Governance & Identity Experience team at DFINITY,
+# The codebase is owned by the OISY team at DFINITY,
 # supported by the crypto team.
-# For questions, reach out to: <gix@dfinity.org>
-.github/CODEOWNERS @dfinity/gix @dfinity/crypto-team
+# For questions, reach out to: <oisy-wallet@dfinity.org>
+.github/CODEOWNERS @dfinity/gix @dfinity/oisy @dfinity/crypto-team


### PR DESCRIPTION
# Motivation

We are migrating the GitHub [GIX](https://github.com/orgs/dfinity/teams/gix) team to the [OISY](https://github.com/orgs/dfinity/teams/oisy) team. So, first, we need to add the new team as codeowner.
