### PR TITLE
chore: Remove GIX team from CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -15,4 +15,4 @@
 # The codebase is owned by the OISY team at DFINITY,
 # supported by the crypto team.
 # For questions, reach out to: <oisy-wallet@dfinity.org>
-.github/CODEOWNERS @dfinity/gix @dfinity/oisy @dfinity/crypto-team
+.github/CODEOWNERS @dfinity/oisy @dfinity/crypto-team


### PR DESCRIPTION
# Motivation

We are migrating the GitHub [GIX](https://github.com/orgs/dfinity/teams/gix) team to the [OISY](https://github.com/orgs/dfinity/teams/oisy) team. In this PR we remove the old team as codeowner.
