### PR TITLE
chore: change ownership from crypto to consensus

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -2,17 +2,16 @@
 
 # The team members who maintain this repo:
 # @bitdivine - original author and to blame for all the bugs.
-# @randombit - crypto team member; please ask him for reviews when changing core crypt.
-# @fspreiss  - crypto team member
-# @altkdf    - crypto team member
-# @AntonioVentilii - GIX team lead.
+# @randombit - please ask him for reviews when changing core cryptography.
+# @fspreiss
+# @AntonioVentilii
 #
 # Note: These users will receive GitHub notifications for PRs.
 #       The list is kept short to avoid spamming the whole team.
 #       If standard maintainers are not available, please contact GIX.
-* @bitdivine @randombit @fspreiss @altkdf @AntonioVentilii
+* @bitdivine @randombit @fspreiss @AntonioVentilii
 
 # The codebase is owned by the OISY team at DFINITY,
-# supported by the crypto team.
+# supported by the consensus team.
 # For questions, reach out to: <oisy-wallet@dfinity.org>
-.github/CODEOWNERS @dfinity/oisy @dfinity/crypto-team
+.github/CODEOWNERS @dfinity/oisy @dfinity/consensus


### PR DESCRIPTION
Adapts the CODEOWNERS file to change ownership from the crypto team to the consensus team.

Also makes some other minor updates to the CODEOWNERS file.