### PR TITLE
chore: Add Mac temp files to `.gitignore`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,7 @@ tarpaulin-report.html
 
 # Intellij IDEA
 .idea
+
+# Mac OSX temporary files
+.DS_Store
+**/.DS_Store


### PR DESCRIPTION
# Motivation

Ignoring Mac temp files when commiting.  
