### PR TITLE
lint: Setup linter for scripts folder

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -4,6 +4,7 @@ import typescriptParser from '@typescript-eslint/parser';
 
 export default [
 	js.configs.recommended,
+
 	{
 		ignores: [
 			'node_modules/',
@@ -20,14 +21,21 @@ export default [
 			'vitest.config.ts'
 		]
 	},
+
 	{
-		files: ['src/**/*.ts', 'src/**/*.tsx', 'src/__tests__/**/*.ts', 'src/__tests__/**/*.tsx'],
+		files: [
+			'scripts/**/*.ts',
+			'src/**/*.ts',
+			'src/**/*.tsx',
+			'src/__tests__/**/*.ts',
+			'src/__tests__/**/*.tsx'
+		],
 		languageOptions: {
 			parser: typescriptParser,
 			parserOptions: {
 				ecmaVersion: 'latest',
 				sourceType: 'module',
-				project: './tsconfig.json'
+				project: './tsconfig.eslint.json'
 			},
 			globals: {
 				console: 'readonly',
@@ -64,10 +72,18 @@ export default [
 			'no-var': 'error'
 		}
 	},
+
 	{
 		files: ['**/*.test.ts', '**/*.test.js', '**/__tests__/**/*'],
 		rules: {
 			'@typescript-eslint/no-explicit-any': 'off',
+			'no-console': 'off'
+		}
+	},
+
+	{
+		files: ['scripts/**/*.ts'],
+		rules: {
 			'no-console': 'off'
 		}
 	}

--- a/tsconfig.eslint.json
+++ b/tsconfig.eslint.json
@@ -1,0 +1,4 @@
+{
+	"extends": "./tsconfig.json",
+	"exclude": ["vitest.config.ts", "node_modules", "dist"]
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -8,5 +8,5 @@
 		"strict": true,
 		"esModuleInterop": true
 	},
-	"exclude": ["vitest.config.ts", "node_modules", "dist"]
+	"exclude": ["scripts", "vitest.config.ts", "node_modules", "dist"]
 }


### PR DESCRIPTION
# Motivation

We would like to include the scripts folder among the linted files. However, since it is not strictly part of the ;library, we should set the ESLINT configuration specifically for this folder.
