### PR TITLE
devops: Use `node` instead of `vite-node` for publishing

### DIFF
--- a/scripts/package-next
+++ b/scripts/package-next
@@ -5,4 +5,4 @@ set -eux
 npm run build
 
 : Then update the version to SEMANTIC_VERSION-next-DATE e.g. 0.0.1-next-2022-08-05T15:02
-vite-node  ./scripts/update-version.ts
+node  ./scripts/update-version.ts


### PR DESCRIPTION
# Motivation

Instead of using `vite-node`, we can simply use `node` in the script publish the `next` package.