### PR TITLE
[DRAFT] Add exports to make package usable as a library

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,25 @@
 	"version": "1.0.1",
 	"type": "module",
 	"main": "index.js",
+	"types": "dist/index.d.ts",
+	"exports": {
+		".": {
+			"types": "./dist/index.d.ts",
+			"import": "./dist/index.js"
+		},
+		"./ecdsa": {
+			"types": "./dist/ecdsa/index.d.ts",
+			"import": "./dist/ecdsa/index.js"
+		},
+		"./schnorr": {
+			"types": "./dist/schnorr/index.d.ts",
+			"import": "./dist/schnorr/index.js"
+		},
+		"./signer": {
+			"types": "./dist/signer/index.d.ts",
+			"import": "./dist/signer/index.js"
+		}
+	},
 	"publishConfig": {
 		"access": "public"
 	},

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -3,6 +3,8 @@
 		"target": "ES2020",
 		"module": "ESNext",
 		"moduleResolution": "bundler",
+		"declaration": true,
+		"declarationMap": true,
 		"outDir": "dist",
 		"rootDir": "src",
 		"strict": true,


### PR DESCRIPTION
Currently there are no .d.ts files in the published package. This means you can't use this package as a library.

You might want to have more exports like `ecdsa/secp256k1`, I just added a couple to prove the concept, let me know if you want me to add all.