### PR TITLE
Make the library usable in a browser

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,25 @@
 	"version": "1.0.1",
 	"type": "module",
 	"main": "index.js",
+	"types": "dist/index.d.ts",
+	"exports": {
+		".": {
+			"types": "./dist/index.d.ts",
+			"import": "./dist/index.js"
+		},
+		"./ecdsa": {
+			"types": "./dist/ecdsa/index.d.ts",
+			"import": "./dist/ecdsa/index.js"
+		},
+		"./schnorr": {
+			"types": "./dist/schnorr/index.d.ts",
+			"import": "./dist/schnorr/index.js"
+		},
+		"./signer": {
+			"types": "./dist/signer/index.d.ts",
+			"import": "./dist/signer/index.js"
+		}
+	},
 	"publishConfig": {
 		"access": "public"
 	},

--- a/src/chain_code.ts
+++ b/src/chain_code.ts
@@ -1,3 +1,4 @@
+import { getBytes, hexlify } from 'ethers';
 import { blobDecode, blobEncode } from './encoding.js';
 
 /**
@@ -25,8 +26,8 @@ export class ChainCode {
 				`Invalid ChainCode length: expected ${ChainCode.LENGTH * 2} characters, got ${hex_str.length}`
 			);
 		}
-		const bytes = Buffer.from(hex_str, 'hex');
-		return new ChainCode(new Uint8Array(bytes));
+		const bytes = getBytes(`0x${hex_str}`);
+		return new ChainCode(bytes);
 	}
 
 	static fromArray(array: number[]): ChainCode {
@@ -37,7 +38,7 @@ export class ChainCode {
 	 * @returns The chain code as a 64 character hex string.
 	 */
 	toHex(): string {
-		return Buffer.from(this.bytes).toString('hex');
+		return hexlify(this.bytes).slice(2);
 	}
 
 	/**

--- a/src/ecdsa/secp256k1.ts
+++ b/src/ecdsa/secp256k1.ts
@@ -3,6 +3,7 @@ import { hmac } from '@noble/hashes/hmac';
 import { sha512 } from '@noble/hashes/sha2';
 import { bytesToHex } from '@noble/hashes/utils';
 import { type AffinePoint, ProjectivePoint } from '@noble/secp256k1';
+import { getBytes, hexlify } from 'ethers';
 import { ChainCode } from '../chain_code.js';
 import { blobDecode, blobEncode } from '../encoding.js';
 export { ChainCode };
@@ -216,15 +217,15 @@ export class Sec1EncodedPublicKey {
 				`Invalid PublicKey length: expected ${Sec1EncodedPublicKey.LENGTH * 2} characters, got ${hex.length}`
 			);
 		}
-		const bytes = Buffer.from(hex, 'hex');
-		return new Sec1EncodedPublicKey(new Uint8Array(bytes));
+		const bytes = getBytes(`0x${hex}`);
+		return new Sec1EncodedPublicKey(bytes);
 	}
 
 	/**
 	 * @returns The public key as a 66-character hex string.
 	 */
 	toHex(): string {
-		return this.toBuffer().toString('hex');
+		return hexlify(this.bytes).slice(2);
 	}
 
 	/**

--- a/src/encoding.ts
+++ b/src/encoding.ts
@@ -3,6 +3,7 @@
  * @param path
  * @returns
  */
+import { getBytes, hexlify } from 'ethers';
 export function blobEncode(bytes: Uint8Array): string {
 	return [...bytes].map((p) => blobEncodeU8(p)).join('');
 }
@@ -73,8 +74,7 @@ export function bigintFromBigEndianBytes(bytes: Uint8Array): bigint {
 	if (bytes.length === 0) {
 		return BigInt(0);
 	}
-	const bigEndianHex = '0x' + Buffer.from(bytes).toString('hex');
-	return BigInt(bigEndianHex);
+	return BigInt(hexlify(bytes));
 }
 
 /**
@@ -86,10 +86,9 @@ export function bigintFromLittleEndianHex(hex: string): bigint {
 	if (hex.length === 0) {
 		return BigInt(0);
 	}
-	const leBytes = Buffer.from(hex, 'hex');
-	const beBytes = leBytes.reverse();
-	const beHex = beBytes.toString('hex');
-	return BigInt('0x' + beHex);
+	const leBytes = getBytes(`0x${hex}`);
+	const beBytes = new Uint8Array(leBytes).reverse();
+	return BigInt(hexlify(beBytes));
 }
 
 /**
@@ -98,5 +97,5 @@ export function bigintFromLittleEndianHex(hex: string): bigint {
  * @returns The converted string.
  */
 export function bytesAsHex(array: Uint8Array): string {
-	return Buffer.from(array).toString('hex');
+	return hexlify(array).slice(2);
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -3,6 +3,8 @@
 		"target": "ES2020",
 		"module": "ESNext",
 		"moduleResolution": "bundler",
+		"declaration": true,
+		"declarationMap": true,
 		"outDir": "dist",
 		"rootDir": "src",
 		"strict": true,


### PR DESCRIPTION
Currently node's `Buffer` API is used throughout the code base. While it's not trivial to remove all instances of that as some dependencies like `bitcoinjs-lib` require it, this PR at least changes some instances to ethers helpers (which is already a dependency anyways).

Deriving a public key in a browser works fine with this change. Let me know what you think!